### PR TITLE
Migrate test suite to Node.js native test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {},
   "scripts": {
     "postversion": "git push origin master --tags && npm publish",
-    "test": "node test/convert.js && node test/parse.js"
+    "test": "node --test test/convert.js test/parse.js"
   },
   "keywords": [
     "color",

--- a/test/convert.js
+++ b/test/convert.js
@@ -1,5 +1,6 @@
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
 var convert = require("../convert");
-var assert = require("assert");
 var fixtures = require("./fixtures/convert");
 
 function round(arr) {
@@ -8,31 +9,29 @@ function round(arr) {
 
 function equal(actual, expected) {
   if (!Array.isArray(expected)) {
-    assert.equal(actual, expected);
+    assert.strictEqual(actual, expected);
   } else {
-    assert.deepEqual(round(actual), expected);
+    assert.deepStrictEqual(round(actual), expected);
   }
 }
 
-function test(from, to, colors) {
-  var conversion = convert[from][to];
-  colors.forEach(function(color) {
-    equal(conversion(color[0]), color[1]);
-  });
-}
-
-// dyanmically create tests for hwb...
+// dynamically create tests for hwb...
 for(var angle = 0; angle <= 360; angle ++) {
-  // all extreme value should give black, white or grey
+  // all extreme values should give black, white or grey
   fixtures.hwb.rgb.push([[angle, 0, 100], [0, 0, 0]]);
   fixtures.hwb.rgb.push([[angle, 100, 0], [255, 255, 255]]);
   fixtures.hwb.rgb.push([[angle, 100, 100], [128, 128, 128]]);
 }
 
-// run tests
 for (var from in fixtures) {
   for (var to in fixtures[from]) {
-    console.log("converting: " + from + "2" + to);
-    test(from, to, fixtures[from][to]);
+    describe(from + "2" + to, function() {
+      var conversion = convert[from][to];
+      fixtures[from][to].forEach(function(color) {
+        it(JSON.stringify(color[0]) + " -> " + JSON.stringify(color[1]), function() {
+          equal(conversion(color[0]), color[1]);
+        });
+      });
+    });
   }
 }

--- a/test/convert.js
+++ b/test/convert.js
@@ -25,10 +25,10 @@ for(var angle = 0; angle <= 360; angle ++) {
 
 for (var from in fixtures) {
   for (var to in fixtures[from]) {
-    describe(from + "2" + to, function() {
+    describe(`${from}2${to}`, function() {
       var conversion = convert[from][to];
       fixtures[from][to].forEach(function(color) {
-        it(JSON.stringify(color[0]) + " -> " + JSON.stringify(color[1]), function() {
+        it(`${JSON.stringify(color[0])} -> ${JSON.stringify(color[1])}`, function() {
           equal(conversion(color[0]), color[1]);
         });
       });

--- a/test/parse.js
+++ b/test/parse.js
@@ -10,10 +10,10 @@ var parsers = {
 };
 
 for (var space in parsers) {
-  describe("parse " + space, function() {
+  describe(`parse ${space}`, function() {
     var parser = parsers[space];
     fixtures[space].forEach(function(color) {
-      it(JSON.stringify(color[0]) + " -> " + JSON.stringify(color[1]), function() {
+      it(`${JSON.stringify(color[0])} -> ${JSON.stringify(color[1])}`, function() {
         assert.deepStrictEqual(parser(color[0]), color[1]);
       });
     });

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,5 @@
-var assert = require("assert");
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
 var fixtures = require("./fixtures/parse");
 
 var parsers = {
@@ -8,14 +9,13 @@ var parsers = {
   parse : require("../parse")
 };
 
-function test(from, colors) {
-  var parser = parsers[from];
-  colors.forEach(function(color) {
-    assert.deepEqual(parser(color[0]), color[1]);
+for (var space in parsers) {
+  describe("parse " + space, function() {
+    var parser = parsers[space];
+    fixtures[space].forEach(function(color) {
+      it(JSON.stringify(color[0]) + " -> " + JSON.stringify(color[1]), function() {
+        assert.deepStrictEqual(parser(color[0]), color[1]);
+      });
+    });
   });
-}
-
-for(var space in parsers) {
-  console.log("parsing: " + space);
-  test(space, fixtures[space]);
 }


### PR DESCRIPTION
* Migrate tests from raw assert scripts to node:test with describe/it structure and --test runner
 * Update CI matrix to [22, 24], dropping EOL Node 18 and soon-EOL Node 20
