### PR TITLE
Add main entry point and improve package distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm ci
       - run: npm run typecheck
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,6 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Build types
-        run: npm run build:types
-
       - name: Bump version
         run: npm version ${{ inputs.version_type }}
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # pure-color
 
-[![CI](https://github.com/WickyNilliams/pure-color/actions/workflows/ci.yml/badge.svg)](https://github.com/WickyNilliams/pure-color/actions/workflows/ci.yml)
-
 `pure-color` is a color conversion and parsing library for the browser and node. It offers conversions between `rgb`, `hsl`, `hsv`, `hwb`, `cmyk`, `xyz`, `lab`, `lch`, `hex`. It offers parsing of `rgb(a)`, `hex` and `hsl(a)` strings.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pure-color
 
-[![Build Status](https://travis-ci.org/WickyNilliams/pure-color.svg)](https://travis-ci.org/WickyNilliams/pure-color)
+[![CI](https://github.com/WickyNilliams/pure-color/actions/workflows/ci.yml/badge.svg)](https://github.com/WickyNilliams/pure-color/actions/workflows/ci.yml)
 
 `pure-color` is a color conversion and parsing library for the browser and node. It offers conversions between `rgb`, `hsl`, `hsv`, `hwb`, `cmyk`, `xyz`, `lab`, `lch`, `hex`. It offers parsing of `rgb(a)`, `hex` and `hsl(a)` strings.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ npm install pure-color --save
 
 ## Structure
 
-The library is structured to allow importing of just the functions you need.
+The library is structured to allow importing of just the functions you need. You can also import everything if file size is not a concern (e.g. node environment).
 
 ```js
+// import everything
+import * as color from "pure-color";
+
 // import individual conversion function
 import { rgb2hsl } from "pure-color/convert/rgb2hsl";
 

--- a/convert/rgb2string.js
+++ b/convert/rgb2string.js
@@ -9,9 +9,10 @@ export function rgb2string(rgb) {
     scheme += "a";
   }
 
-  rgb[0] = Math.round(rgb[0]);
-  rgb[1] = Math.round(rgb[1]);
-  rgb[2] = Math.round(rgb[2]);
+  var parts = rgb.slice();
+  parts[0] = Math.round(rgb[0]);
+  parts[1] = Math.round(rgb[1]);
+  parts[2] = Math.round(rgb[2]);
 
-  return `${scheme}(${rgb.join(",")})`;
+  return `${scheme}(${parts.join(",")})`;
 }

--- a/convert/rgb2string.js
+++ b/convert/rgb2string.js
@@ -3,16 +3,9 @@
  * @returns {string}
  */
 export function rgb2string(rgb) {
-  var scheme = "rgb";
-
-  if(rgb.length === 4) {
-    scheme += "a";
+  const [r, g, b, a] = rgb;
+  if (a !== undefined) {
+    return `rgba(${Math.round(r)},${Math.round(g)},${Math.round(b)},${a})`;
   }
-
-  var parts = rgb.slice();
-  parts[0] = Math.round(rgb[0]);
-  parts[1] = Math.round(rgb[1]);
-  parts[2] = Math.round(rgb[2]);
-
-  return `${scheme}(${parts.join(",")})`;
+  return `rgb(${Math.round(r)},${Math.round(g)},${Math.round(b)})`;
 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,26 @@
+export { cmyk2rgb } from "./convert/cmyk2rgb.js";
+export { hsl2hsv } from "./convert/hsl2hsv.js";
+export { hsl2rgb } from "./convert/hsl2rgb.js";
+export { hsl2string } from "./convert/hsl2string.js";
+export { hsv2hsl } from "./convert/hsv2hsl.js";
+export { hsv2rgb } from "./convert/hsv2rgb.js";
+export { hwb2rgb } from "./convert/hwb2rgb.js";
+export { lab2lch } from "./convert/lab2lch.js";
+export { lab2xyz } from "./convert/lab2xyz.js";
+export { lch2lab } from "./convert/lch2lab.js";
+export { rgb2cmyk } from "./convert/rgb2cmyk.js";
+export { rgb2grayscale } from "./convert/rgb2grayscale.js";
+export { rgb2hex } from "./convert/rgb2hex.js";
+export { rgb2hsl } from "./convert/rgb2hsl.js";
+export { rgb2hsv } from "./convert/rgb2hsv.js";
+export { rgb2hwb } from "./convert/rgb2hwb.js";
+export { rgb2lab } from "./convert/rgb2lab.js";
+export { rgb2string } from "./convert/rgb2string.js";
+export { rgb2xyz } from "./convert/rgb2xyz.js";
+export { xyz2lab } from "./convert/xyz2lab.js";
+export { xyz2rgb } from "./convert/xyz2rgb.js";
+
+export { parse } from "./parse/parse.js";
+export { hex } from "./parse/hex.js";
+export { hsl } from "./parse/hsl.js";
+export { rgb } from "./parse/rgb.js";

--- a/index.js
+++ b/index.js
@@ -21,6 +21,6 @@ export { xyz2lab } from "./convert/xyz2lab.js";
 export { xyz2rgb } from "./convert/xyz2rgb.js";
 
 export { parse } from "./parse/parse.js";
-export { hex } from "./parse/hex.js";
-export { hsl } from "./parse/hsl.js";
-export { rgb } from "./parse/rgb.js";
+export { hex as parseHex } from "./parse/hex.js";
+export { hsl as parseHsl } from "./parse/hsl.js";
+export { rgb as parseRgb } from "./parse/rgb.js";

--- a/package.json
+++ b/package.json
@@ -15,6 +15,17 @@
     "url": "https://github.com/WickyNilliams/pure-color.git"
   },
   "license": "MIT",
+  "files": [
+    "convert",
+    "parse",
+    "util",
+    "types",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
     "typescript": "^5.9.3"
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "pure-color",
   "description": "Pure functions for color conversion and parsing",
   "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./convert/*": "./convert/*",
+    "./parse/*": "./parse/*"
+  },
   "types": "types/index.d.ts",
   "typesVersions": {
     "*": {
@@ -33,7 +39,8 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build:types": "tsc",
-    "test": "node --test test/convert.js test/parse.js"
+    "test": "node --test test/convert.js test/parse.js",
+    "prepublishOnly": "npm run build:types"
   },
   "keywords": [
     "color",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "license": "MIT",
   "files": [
+    "index.js",
     "convert",
     "parse",
     "util",


### PR DESCRIPTION
- Add main barrel export (`index.js`) with all converters and parsers
- Add `"main"` and `"exports"` fields to lock down public API surface
- Add `prepublishOnly` script to auto-build types on publish, remove redundant CI step
- Simplify `rgb2string`, rename parse re-exports for clarity
- Remove stale CI badge from README